### PR TITLE
Support for js platform

### DIFF
--- a/buildSrc/src/main/kotlin/deps/deps.kt
+++ b/buildSrc/src/main/kotlin/deps/deps.kt
@@ -11,6 +11,7 @@ object Kotlin : Group("org.jetbrains.kotlin", "1.3.72") {
         object Core {
             val Common = artifact("kotlinx-coroutines-core-common")
             val Jvm = artifact("kotlinx-coroutines-core")
+            val Js = artifact("kotlinx-coroutines-core-js")
             val Native = artifact("kotlinx-coroutines-core-native")
         }
     }
@@ -28,5 +29,6 @@ object Kotlin : Group("org.jetbrains.kotlin", "1.3.72") {
         val Common = artifact("kotlin-test-common")
         val JUnit5 = artifact("kotlin-test-junit5")
         val Jvm = artifact("kotlin-test")
+        val Js = artifact("kotlin-test-js")
     }
 }

--- a/oolong/build.gradle.kts
+++ b/oolong/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
 
 kotlin {
     jvm()
+    js()
 
     sourceSets {
         val commonMain by getting {
@@ -40,6 +41,18 @@ kotlin {
             dependencies {
                 implementation(deps.Kotlin.Test.Jvm)
                 implementation(deps.Kotlin.Test.JUnit5)
+            }
+        }
+
+        val jsMain by getting {
+            dependencies {
+                api(deps.Kotlin.Coroutines.Core.Js)
+            }
+        }
+
+        val jsTest by getting {
+            dependencies {
+                implementation(deps.Kotlin.Test.Js)
             }
         }
 

--- a/oolong/src/commonTest/kotlin/oolong/RuntimeTest.kt
+++ b/oolong/src/commonTest/kotlin/oolong/RuntimeTest.kt
@@ -2,13 +2,14 @@ package oolong
 
 import oolong.delay.delay
 import oolong.effect.none
+import kotlin.js.JsName
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
 
 class RuntimeTest {
 
-    @Test
+    @Test @JsName("runtimeShouldCallRenderInitially")
     fun `runtime should call render initially`() = test { resolve ->
         val initialState = 1
         Oolong.runtime(
@@ -22,7 +23,7 @@ class RuntimeTest {
         )
     }
 
-    @Test
+    @Test @JsName("runtimeShouldCallRenderAfterDispatch")
     fun `runtime should call render after dispatch`() = test { resolve ->
         var count = 0
         Oolong.runtime(
@@ -47,7 +48,7 @@ class RuntimeTest {
         )
     }
 
-    @Test
+    @Test @JsName("effectsDoNotBlockRuntime")
     fun `effects do not block runtime`() = test { resolve ->
         val states = mutableListOf<String>()
         Oolong.runtime(
@@ -72,7 +73,7 @@ class RuntimeTest {
         )
     }
 
-    @Test
+    @Test @JsName("runtimeShouldNotCallUpdateViewRenderIfDisposed")
     fun `runtime should not call update view render if disposed`() = test { resolve ->
         var initialRender = true
         Oolong.runtime(

--- a/oolong/src/commonTest/kotlin/oolong/effect/EffectTest.kt
+++ b/oolong/src/commonTest/kotlin/oolong/effect/EffectTest.kt
@@ -6,6 +6,7 @@ import oolong.Effect
 import oolong.delay.delay
 import oolong.effect
 import oolong.runBlocking
+import kotlin.js.JsName
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
@@ -20,7 +21,7 @@ class EffectTest {
         object NoOp : ChildMsg()
     }
 
-    @Test
+    @Test @JsName("mapShouldDispatchMappedMessage")
     fun `map should dispatch mapped message`() = runBlocking {
         val childEffect: Effect<ChildMsg> = { dispatch -> dispatch(ChildMsg.NoOp) }
         val parentEffect = map(childEffect) { ParentMsg.ChildMsgW(it) }
@@ -28,7 +29,7 @@ class EffectTest {
         delay(10)
     }
 
-    @Test
+    @Test @JsName("batchShouldNotBlockIteration")
     fun `batch should not block iteration`() = runBlocking {
         val delay = 10L
         val range = 1..10
@@ -44,7 +45,7 @@ class EffectTest {
         assertEquals(range.toList(), messages.sorted())
     }
 
-    @Test
+    @Test @JsName("disposableEffectShouldCancelEffectWhenDisposed")
     fun `disposable effect should cancel effect when disposed`() = runBlocking {
         val delay = 10L
         val (effect, dispose) = disposableEffect(delay(delay) { })

--- a/oolong/src/commonTest/kotlin/oolong/util.kt
+++ b/oolong/src/commonTest/kotlin/oolong/util.kt
@@ -9,21 +9,23 @@ import kotlin.test.fail
 expect fun <T> runBlocking(
     context: CoroutineContext = EmptyCoroutineContext,
     block: suspend CoroutineScope.() -> T
-): T
+)
 
 fun test(
     timeout: Long = 1000,
     step: Long = 10,
     block: (resolve: () -> Unit) -> Any?
-) = runBlocking {
-    var elapsed = 0L
-    var resolved = false
-    block { resolved = true }
-    while (!resolved) {
-        delay(step)
-        elapsed += step
-        if (elapsed >= timeout) {
-            fail("Test exceeded max execution time of $timeout ms.")
+) {
+    runBlocking {
+        var elapsed = 0L
+        var resolved = false
+        block { resolved = true }
+        while (!resolved) {
+            delay(step)
+            elapsed += step
+            if (elapsed >= timeout) {
+                fail("Test exceeded max execution time of $timeout ms.")
+            }
         }
     }
 }

--- a/oolong/src/jsTest/kotlin/oolong/runBlocking.kt
+++ b/oolong/src/jsTest/kotlin/oolong/runBlocking.kt
@@ -1,9 +1,11 @@
 package oolong
 
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 
 actual fun <T> runBlocking(
     context: CoroutineContext,
     block: suspend CoroutineScope.() -> T
-) { kotlinx.coroutines.runBlocking(context, block) }
+) {
+    GlobalScope.async { block(this) }
+}

--- a/oolong/src/nativeTest/kotlin/oolong/runBlocking.kt
+++ b/oolong/src/nativeTest/kotlin/oolong/runBlocking.kt
@@ -6,4 +6,4 @@ import kotlin.coroutines.CoroutineContext
 actual fun <T> runBlocking(
     context: CoroutineContext,
     block: suspend CoroutineScope.() -> T
-): T = kotlinx.coroutines.runBlocking(context, block)
+)  { kotlinx.coroutines.runBlocking(context, block) }


### PR DESCRIPTION
Hi, I wanted to test Oolong on JavaScript. 

I added the target and to implement `runBlocking` for the tests I removed the returned type. I also added `@JsName()' for test methods, the js platform doesn't support spaces in method names.

I don't know if it is the good way to do it but I was able to play with Oolong :).

I'm using [Bulma](https://bulma.io) and [bulma-kotlin](https://github.com/centyllion/bulma-kotlin):
<img width="182" alt="Capture d’écran 2020-06-01 à 08 02 41" src="https://user-images.githubusercontent.com/3531483/83380473-54438600-a3de-11ea-8e77-535865510d9f.png">
