### PR TITLE
Deprecate Dispose in favor of Job.

### DIFF
--- a/oolong/src/commonMain/kotlin/oolong/Oolong.kt
+++ b/oolong/src/commonMain/kotlin/oolong/Oolong.kt
@@ -2,22 +2,48 @@ package oolong
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 import kotlin.jvm.JvmOverloads
 
 /**
+ * Create a runtime.
+ */
+@JvmOverloads
+fun <Model : Any, Msg : Any, Props : Any> runtime(
+    init: Init<Model, Msg>,
+    update: Update<Model, Msg>,
+    view: View<Model, Props>,
+    render: Render<Msg, Props>,
+    runtimeContext: CoroutineContext = Dispatchers.Default,
+    renderContext: CoroutineContext = Dispatchers.Main,
+    effectContext: CoroutineContext = Dispatchers.Default
+): Job {
+    val runtime = RuntimeImpl(
+        init, update, view, render,
+        runtimeContext, renderContext, effectContext
+    )
+    return runtime.job
+}
+
+/**
  * Oolong runtime module.
  */
 object Oolong {
-
     /**
      * Create a runtime.
      */
     @JvmOverloads
+    @Deprecated(
+        "Use oolong.runtime(init, update, view, render, runtimeContext, renderContext, effectContext) instead",
+        ReplaceWith(
+            "oolong.runtime(init, update, view, render, runtimeContext, renderContext, effectContext)",
+            "oolong"
+        )
+    )
     fun <Model : Any, Msg : Any, Props : Any> runtime(
         init: Init<Model, Msg>,
         update: Update<Model, Msg>,
@@ -31,48 +57,44 @@ object Oolong {
             init, update, view, render,
             runtimeContext, renderContext, effectContext
         )
-        return { runtime.dispose() }
+        return { runtime.job.cancel() }
     }
 
-    private class RuntimeImpl<Model : Any, Msg : Any, Props : Any>(
-        init: Init<Model, Msg>,
-        private val update: Update<Model, Msg>,
-        private val view: View<Model, Props>,
-        private val render: Render<Msg, Props>,
-        private val runtimeContext: CoroutineContext,
-        private val renderContext: CoroutineContext,
-        private val effectContext: CoroutineContext
-    ) : CoroutineScope {
+}
 
-        private lateinit var currentState: Model
+private class RuntimeImpl<Model : Any, Msg : Any, Props : Any>(
+    init: Init<Model, Msg>,
+    private val update: Update<Model, Msg>,
+    private val view: View<Model, Props>,
+    private val render: Render<Msg, Props>,
+    private val runtimeContext: CoroutineContext,
+    private val renderContext: CoroutineContext,
+    private val effectContext: CoroutineContext
+) : CoroutineScope {
 
-        override val coroutineContext: CoroutineContext
-            get() = runtimeContext + SupervisorJob()
+    val job: Job = SupervisorJob()
 
-        init {
-            launch(runtimeContext) { step(init()) }
+    override val coroutineContext: CoroutineContext
+        get() = runtimeContext + job
+
+    private lateinit var currentState: Model
+
+    init {
+        launch(runtimeContext) { step(init()) }
+    }
+
+    private fun dispatch(msg: Msg) {
+        if (isActive) {
+            launch(runtimeContext) { step(update(msg, currentState)) }
         }
+    }
 
-        private fun dispatch(msg: Msg) {
-            if (isActive) {
-                launch(runtimeContext) { step(update(msg, currentState)) }
-            }
-        }
-
-        private fun step(next: Next<Model, Msg>) {
-            val (state, effect) = next
-            val props = view(state)
-            currentState = state
-            launch(renderContext) { render(props, ::dispatch) }
-            launch(effectContext) { effect(::dispatch) }
-        }
-
-        fun dispose() {
-            if (isActive) {
-                cancel()
-            }
-        }
-
+    private fun step(next: Next<Model, Msg>) {
+        val (state, effect) = next
+        val props = view(state)
+        currentState = state
+        launch(renderContext) { render(props, ::dispatch) }
+        launch(effectContext) { effect(::dispatch) }
     }
 
 }

--- a/oolong/src/commonMain/kotlin/oolong/effect/util.kt
+++ b/oolong/src/commonMain/kotlin/oolong/effect/util.kt
@@ -1,6 +1,5 @@
 package oolong.effect
 
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -38,23 +37,13 @@ fun <A : Any, B : Any> map(effect: Effect<A>, f: (A) -> B): Effect<B> =
 /**
  * Create a [Pair] of [Effect] and [Dispose].
  */
-fun <Msg : Any> cancellableEffect(effect: Effect<Msg>): Pair<Effect<Msg>, Job> {
+@Deprecated("To be removed in the next minor release")
+fun <Msg : Any> disposableEffect(effect: Effect<Msg>): Pair<Effect<Msg>, Dispose> {
     val supervisor = SupervisorJob()
+    val dispose = { supervisor.cancel() }
     return effect<Msg> { dispatch ->
-        withContext(supervisor) {
+        withContext(coroutineContext + supervisor) {
             effect(dispatch)
         }
-    } to supervisor
-}
-
-/**
- * Create a [Pair] of [Effect] and [Dispose].
- */
-@Deprecated(
-    "Use cancellableEffect(effect) instead",
-    ReplaceWith("cancellableEffect(effect)")
-)
-fun <Msg : Any> disposableEffect(effect: Effect<Msg>): Pair<Effect<Msg>, Dispose> {
-    val (effect, job) = cancellableEffect(effect)
-    return effect to { job.cancel() }
+    } to dispose
 }

--- a/oolong/src/commonMain/kotlin/oolong/types.kt
+++ b/oolong/src/commonMain/kotlin/oolong/types.kt
@@ -52,6 +52,10 @@ typealias Render<Msg, Props> = (props: Props, dispatch: Dispatch<Msg>) -> Any?
 /**
  * Stops the function and cleans up resources
  */
+@Deprecated(
+    "Use Job instead",
+    ReplaceWith("Job", "kotlinx.coroutines.Job")
+)
 typealias Dispose = () -> Unit
 
 /**

--- a/oolong/src/jvmTest/kotlin/oolong/effect/EffectTest.kt
+++ b/oolong/src/jvmTest/kotlin/oolong/effect/EffectTest.kt
@@ -40,15 +40,6 @@ class EffectTest {
     }
 
     @Test
-    fun `cancellable effect should cancel effect when disposed`() = runBlockingTest {
-        val delay = 10L
-        val (effect, job) = cancellableEffect(delay(delay) { })
-        launch { effect { fail("Effect was disposed and should not be called.") } }
-        job.cancel()
-        advanceTimeBy(delay)
-    }
-
-    @Test
     fun `disposable effect should cancel effect when disposed`() = runBlockingTest {
         val delay = 10L
         val (effect, dispose) = disposableEffect(delay(delay) { })

--- a/oolong/src/jvmTest/kotlin/oolong/effect/EffectTest.kt
+++ b/oolong/src/jvmTest/kotlin/oolong/effect/EffectTest.kt
@@ -40,6 +40,15 @@ class EffectTest {
     }
 
     @Test
+    fun `cancellable effect should cancel effect when disposed`() = runBlockingTest {
+        val delay = 10L
+        val (effect, job) = cancellableEffect(delay(delay) { })
+        launch { effect { fail("Effect was disposed and should not be called.") } }
+        job.cancel()
+        advanceTimeBy(delay)
+    }
+
+    @Test
     fun `disposable effect should cancel effect when disposed`() = runBlockingTest {
         val delay = 10L
         val (effect, dispose) = disposableEffect(delay(delay) { })


### PR DESCRIPTION
Currently, the `Dispose` returned from `Oolong.runtime` simply cancels a supervising job. Coroutines are language primitives at this point and we should expose the `Job` instead of obscuring it with another type.