### PR TITLE
Deprecate type aliases in preference of underlying types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `oolong.Oolong.runtime` deprecated in favor of `oolong.runtime`.
 - `disposableEffect` deprecated.
 - Allow incoming types to be nullable.
+- Deprecate `Next<Model, Msg>` in preference of underlying type `Pair<Model, Effect<Msg>>`.
 
 ## [2.0.7] - 2020-08-17
 ### Added

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -32,7 +32,7 @@ The update function uses these two concepts to take a previous state and transfo
 So far we have mentioned two conventions: models are `data` classes, and messages are `sealed` classes. You can see in the function below how those modifiers are leveraged. The message type is able to be determined in an exhaustive manner using the `when` block. The new state is created by mutating the old state with the `copy` function.
 
 ```kotlin
-val update: Update<Model, Msg> = { msg, model ->
+val update: (Msg, Model) -> Pair<Model, Effect<Msg>> = { msg, model ->
     when (msg) {
         Msg.Increment -> model.copy(count = model.count + 1) to none()
         Msg.Decrement -> model.copy(count = model.count - 1) to none()
@@ -65,7 +65,7 @@ The view function, as mentioned above, takes the current state its argument and 
 * `decrement` - a function which dispatches the `Decrement` message.
 
 ```kotlin
-val view: View<Model, Props> = { model ->
+val view: (Model) -> Props = { model ->
     Props(
         model.count,
         { dispatch -> dispatch(Msg.Increment) },
@@ -83,7 +83,7 @@ Now that we've built the core components of our application we need a few more t
 To get the runtime loop started, we first need to know what the initial state is. We do this by definiting an initialization function. This function is similar to the `update` function, however it takes no arguments. By convention, it is often desireable to define defaults in the model class and simply return a new instance from the init function.
 
 ```kotlin
-val init: Init<Model, Msg> = {
+val init: () -> Pair<Model, Effect<Msg>> = {
     Model() to none()
 }
 ```
@@ -93,7 +93,7 @@ val init: Init<Model, Msg> = {
 We also need to know how to render the view properties returned by the view function. Each target platform does this by implementing a render function which takes the view properties and a dispatch function as arguments. The dispatch function can be invoked to send messages to the update function.
 
 ```kotlin
-val render: Render<Msg, Props> = { props, dispatch ->
+val render: (Props, Dispatch<Msg>) -> Any? = { props, dispatch ->
     // Platform specific rendering
     countLabel.text = "${props.count}"
     incrementButton.setOnClickListener { dispatch(props.increment()) }

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,18 +30,18 @@ class Props(
     val decrement: (Dispatch<Msg>) -> Unit
 )
 
-val init: Init<Model, Msg> = { 
+val init: () -> Pair<Model, Effect<Msg>> = { 
     Model() to none()
 }
 
-val update: Update<Model, Msg> = { msg, model ->
+val update: (Msg, Model) -> Pair<Model, Effect<Msg>> = { msg, model ->
     when (msg) {
         Msg.Increment -> model.copy(count = model.count + 1)
         Msg.Decrement -> model.copy(count = model.count - 1)
     } to none()
 }
 
-val view: View<Model, Props> = { model ->
+val view: (Model) -> Props = { model ->
     Props(
         model.count,
         { dispatch -> dispatch(Msg.Increment) },
@@ -68,10 +68,10 @@ import oolong.View
 import oolong.effect.none
 
 fun <Model, Msg, Props> CoroutineScope.runtime(
-    init: Init<Model, Msg>,
-    update: Update<Model, Msg>,
-    view: View<Model, Props>,
-    render: Render<Msg, Props>,
+    init: () -> Pair<Model, Effect<Msg>>,
+    update: (Msg, Model) -> Pair<Model, Effect<Msg>>,
+    view: (Model) -> Props,
+    render: (Props, Dispatch<Msg>) -> Any?,
 ): Dispose = Oolong.runtime(
     init, 
     update, 
@@ -98,18 +98,18 @@ class Props(
     val decrement: (Dispatch<Msg>) -> Unit
 )
 
-val init: Init<Model, Msg> = { 
+val init: () -> Pair<Model, Effect<Msg>> = { 
     Model() to none()
 }
 
-val update: Update<Model, Msg> = { msg, model ->
+val update: (Msg, Model) -> Pair<Model, Effect<Msg>> = { msg, model ->
     when (msg) {
         Msg.Increment -> model.copy(count = model.count + 1)
         Msg.Decrement -> model.copy(count = model.count - 1)
     } to none()
 }
 
-val view: View<Model, Props> = { model ->
+val view: (Model) -> Props = { model ->
     Props(
         model.count,
         { dispatch -> dispatch(Msg.Increment) },
@@ -120,7 +120,7 @@ val view: View<Model, Props> = { model ->
 fun main() {
     runBlocking {
 //sampleStart
-        val render: Render<Msg, Props> = { props, dispatch ->
+        val render: (Props, Dispatch<Msg>) -> Any? = { props, dispatch ->
             // Print the current count
             println("count: ${props.count}")
 

--- a/docs/recipes/navigation.md
+++ b/docs/recipes/navigation.md
@@ -6,7 +6,7 @@ Since MVU architecture is fractal and composable, navigation is simply an excerc
 
 The navigation component needs to have an awareness of the logical screens in order to delegate to them, so we must create `Model`, `Msg`, and `Props` wrappers for each screen.
 
-A navigation component's model is comprised of wrapper instances for each screen:
+A navigation component's model consists of wrapper instances for each screen:
 
 ```kotlin
 sealed class Model {
@@ -24,7 +24,7 @@ sealed class Msg {
     data class List(msg: List.Msg) : Msg()
     data class Detail(msg: Detail.Msg) : Msg()
     // Navigation
-    data class SetScreen(next: Next<Model, Msg>): Msg()
+    data class SetScreen(next: Pair<Model, Effect<Msg>>): Msg()
 }
 ```
 
@@ -42,7 +42,7 @@ sealed class Props {
 
 Now that the appropriate types have been defined, we can define program functions which delegate to each screen. Let's look each function in order starting with `init`.
 
-Oolong provides a few utility functions for common use-cases and one of these is [`bimap`](/oolong/oolong.next/bimap). The bimap function transforms an instance of `Next<A, B>` to an instance of `Next<C, D>`. We're goint to use `List` as our initial screen, so in this case we're bimapping from an instance of `Next<List.Model, List.Msg>` to an instance of `Next<Model, Msg>`.
+Oolong provides a few utility functions for common use-cases and one of these is [`bimap`](/oolong/oolong.next/bimap). The bimap function transforms an instance of `Pair<A, Effect<B>>` to an instance of `Pair<C, Effect<D>>`. We're going to use `List` as our initial screen, so in this case we're bimapping from an instance of `Pair<List.Model , Effect<List.Msg >>` to an instance of `Pair<Model, Effect<Msg>>`.
 
 In other words, we're taking the `List.Model` and `List.Msg` returned from `List.init` and wrapping them in the delegated types of `Model.List` and `Msg.List`.
 

--- a/docs/recipes/navigation.md
+++ b/docs/recipes/navigation.md
@@ -47,7 +47,7 @@ Oolong provides a few utility functions for common use-cases and one of these is
 In other words, we're taking the `List.Model` and `List.Msg` returned from `List.init` and wrapping them in the delegated types of `Model.List` and `Msg.List`.
 
 ```kotlin
-val init: Init<Model, Msg> = {
+val init: () -> Pair<Model, Effect<Msg>> = {
     bimap(List.init(), Model::List, Msg::List)
 }
 ```
@@ -55,7 +55,7 @@ val init: Init<Model, Msg> = {
 The same `bimap` function is used to delegate to screens in the `update` function. If the `msg` is an instance of a screen message wrapper, then we delegate to that screen using `bimap`. However, we receive a `SetScreen` message, we simply return the next value provided.
 
 ```kotlin
-val update: Update<Model, Msg> = { msg, model ->
+val update: (Msg, Model) -> Pair<Model, Effect<Msg>> = { msg, model ->
     when (msg) {
         is Msg.List -> {
             bimap(
@@ -81,7 +81,7 @@ val update: Update<Model, Msg> = { msg, model ->
 The `view` function is quite simple, as we only need to wrap the screen's props with it's respected instance in the navigation props.
 
 ```kotlin
-val view: View<Model, Props> = { model ->
+val view: (Model) -> Props = { model ->
     when (model) {
         is Model.List -> {
             Props.List(List.view(model.model))
@@ -96,7 +96,7 @@ val view: View<Model, Props> = { model ->
 Finally, in the `view` function we unwrap the props and delegate to each screen's render function. There is one additional consideration we need to take in this function, however, which is mapping the `dispatch` function from the screen's `Msg` type to the parent's. For this, we can use the provided [`contramap`](/oolong/oolong.dispatch/contramap) fuction.
 
 ```kotlin
-val render: Render<Msg, Props> = { props, dispatch ->
+val render: (Props, Dispatch<Msg>) -> Any? = { props, dispatch ->
     when (props) {
         is Props.List -> {
             List.render(props.props, contramap(dispatch, Msg::List))

--- a/oolong/src/commonMain/kotlin/oolong/Oolong.kt
+++ b/oolong/src/commonMain/kotlin/oolong/Oolong.kt
@@ -91,7 +91,7 @@ private class RuntimeImpl<Model, Msg, Props>(
         }
     }
 
-    private fun step(next: Next<Model, Msg>) {
+    private fun step(next: Pair<Model, Effect<Msg>>) {
         val (state, effect) = next
         val props = view(state)
         currentState = state

--- a/oolong/src/commonMain/kotlin/oolong/dispatch/util.kt
+++ b/oolong/src/commonMain/kotlin/oolong/dispatch/util.kt
@@ -5,33 +5,7 @@ import oolong.Dispatch
 /**
  * Contramap from [Dispatch] of [A] to [Dispatch] of [B]
  *
- * `contramap` can be used to map a dispatch function from a parent `Msg` to a child `Msg`. A typical use for
- * `contramap` is compositional screen management.
- *
- * Example:
- *
- * ```kotlin
- * sealed class Props {
- *     data class Home(val props: HomeProps): Props()
- *     data class Settings(val props: SettingsProps): Props()
- * }
- *
- * sealed class Msg {
- *     data class Home(val msg: HomeMsg) : Msg()
- *     data class Settings(val msg: SettingsMsg) : Msg()
- * }
- *
- * val render: Render<Msg, Props> = { props: Props, dispatch: Dispatch<Msg> ->
- *     when (props) {
- *         is Props.Home -> {
- *             homeRender(props.props, contramap(dispatch, Msg::Home))
- *         }
- *         is Props.Settings -> {
- *             settingsRender(props.props, contramap(dispatch, Msg::Settings))
- *         }
- *     }
- * }
- * ```
+ * See: [https://oolong-kt.org/recipes/navigation/](https://oolong-kt.org/recipes/navigation/)
  */
 fun <A, B> contramap(dispatch: Dispatch<A>, f: (B) -> A): Dispatch<B> =
     { b -> dispatch(f(b)) }

--- a/oolong/src/commonMain/kotlin/oolong/next/util.kt
+++ b/oolong/src/commonMain/kotlin/oolong/next/util.kt
@@ -1,5 +1,6 @@
 package oolong.next
 
+import oolong.Effect
 import oolong.Next
 import oolong.effect.map
 
@@ -47,5 +48,5 @@ import oolong.effect.map
  *     }
  * }
  */
-fun <A, B, C, D> bimap(next: Next<A, B>, fa: (A) -> C, fb: (B) -> D): Next<C, D> =
+fun <A, B, C, D> bimap(next: Pair<A, Effect<B>>, fa: (A) -> C, fb: (B) -> D): Pair<C, Effect<D>> =
     fa(next.first) to map(next.second, fb)

--- a/oolong/src/commonMain/kotlin/oolong/next/util.kt
+++ b/oolong/src/commonMain/kotlin/oolong/next/util.kt
@@ -1,52 +1,12 @@
 package oolong.next
 
 import oolong.Effect
-import oolong.Next
 import oolong.effect.map
 
 /**
- * Map from [Next] of [A] and [B] to [Next] of [C] and [D]
+ * Map from [Pair] of [A] and [Effect] of [B] to [Pair] of [C] and Effect of [D].
  *
- * `bimap` can be used to map an init or update function from a child `Next` to a parent `Next`. A typical use for
- * `bimap` is compositional screen management.
- *
- * Example:
- *
- * ```kotlin
- * sealed class Model {
- *     data class Home(val model: HomeModel): Model()
- *     data class Settings(val model: SettingsModel): Model()
- * }
- *
- * sealed class Msg {
- *     data class Home(val msg: HomeMsg) : Msg()
- *     data class Settings(val msg: SettingsMsg) : Msg()
- * }
- *
- * val update: Update<Model, Msg> = { msg: Msg, model: Model ->
- *     when (msg) {
- *         is Msg.Home -> {
- *             when (model) {
- *                 is Model.Home -> bimap(
- *                     homeUpdate(msg.msg, model.model),
- *                     Model::Home,
- *                     Msg::Home
- *                 )
- *                 else -> model to none()
- *             }
- *         }
- *         is Msg.Settings -> {
- *             when (model) {
- *                 is Model.Settings -> bimap(
- *                     settingsUpdate(msg.msg, model.model),
- *                     Model::Settings,
- *                     Msg::Settings
- *                 )
- *                 else -> model to none()
- *             }
- *         }
- *     }
- * }
+ * See: [https://oolong-kt.org/recipes/navigation/](https://oolong-kt.org/recipes/navigation/)
  */
 fun <A, B, C, D> bimap(next: Pair<A, Effect<B>>, fa: (A) -> C, fb: (B) -> D): Pair<C, Effect<D>> =
     fa(next.first) to map(next.second, fb)

--- a/oolong/src/commonMain/kotlin/oolong/runtime.kt
+++ b/oolong/src/commonMain/kotlin/oolong/runtime.kt
@@ -14,10 +14,10 @@ import kotlin.jvm.JvmOverloads
  */
 @JvmOverloads
 fun <Model, Msg, Props> runtime(
-    init: Init<Model, Msg>,
-    update: Update<Model, Msg>,
-    view: View<Model, Props>,
-    render: Render<Msg, Props>,
+    init: () -> Pair<Model, Effect<Msg>>,
+    update: (Msg, Model) -> Pair<Model, Effect<Msg>>,
+    view: (Model) -> Props,
+    render: (Props, Dispatch<Msg>) -> Any?,
     runtimeContext: CoroutineContext = Dispatchers.Default,
     renderContext: CoroutineContext = Dispatchers.Main,
     effectContext: CoroutineContext = Dispatchers.Default
@@ -45,10 +45,10 @@ object Oolong {
         )
     )
     fun <Model, Msg, Props> runtime(
-        init: Init<Model, Msg>,
-        update: Update<Model, Msg>,
-        view: View<Model, Props>,
-        render: Render<Msg, Props>,
+        init: () -> Pair<Model, Effect<Msg>>,
+        update: (Msg, Model) -> Pair<Model, Effect<Msg>>,
+        view: (Model) -> Props,
+        render: (Props, Dispatch<Msg>) -> Any?,
         runtimeContext: CoroutineContext = Dispatchers.Default,
         renderContext: CoroutineContext = Dispatchers.Main,
         effectContext: CoroutineContext = Dispatchers.Default
@@ -63,10 +63,10 @@ object Oolong {
 }
 
 private class RuntimeImpl<Model, Msg, Props>(
-    init: Init<Model, Msg>,
-    private val update: Update<Model, Msg>,
-    private val view: View<Model, Props>,
-    private val render: Render<Msg, Props>,
+    init: () -> Pair<Model, Effect<Msg>>,
+    private val update: (Msg, Model) -> Pair<Model, Effect<Msg>>,
+    private val view: (Model) -> Props,
+    private val render: (Props, Dispatch<Msg>) -> Any?,
     private val runtimeContext: CoroutineContext,
     private val renderContext: CoroutineContext,
     private val effectContext: CoroutineContext

--- a/oolong/src/commonMain/kotlin/oolong/runtime.kt
+++ b/oolong/src/commonMain/kotlin/oolong/runtime.kt
@@ -13,6 +13,19 @@ import kotlin.jvm.JvmOverloads
  * Create a runtime.
  */
 @JvmOverloads
+fun <Model, Msg> runtime(
+    init: () -> Pair<Model, Effect<Msg>>,
+    update: (Msg, Model) -> Pair<Model, Effect<Msg>>,
+    view: (Model, Dispatch<Msg>) -> Any?,
+    runtimeContext: CoroutineContext = Dispatchers.Default,
+    renderContext: CoroutineContext = Dispatchers.Main,
+    effectContext: CoroutineContext = Dispatchers.Default
+): Job = runtime(init, update, { it }, view, runtimeContext, renderContext, effectContext)
+
+/**
+ * Create a runtime.
+ */
+@JvmOverloads
 fun <Model, Msg, Props> runtime(
     init: () -> Pair<Model, Effect<Msg>>,
     update: (Msg, Model) -> Pair<Model, Effect<Msg>>,

--- a/oolong/src/commonMain/kotlin/oolong/types.kt
+++ b/oolong/src/commonMain/kotlin/oolong/types.kt
@@ -19,12 +19,16 @@ typealias Effect<Msg> = suspend CoroutineScope.(dispatch: Dispatch<Msg>) -> Any?
 /**
  * A pair of the next state and side-effects
  */
+@Deprecated(
+    "Use Pair<Model, Effect<Msg>> instead",
+    ReplaceWith("Pair<Model, Effect<Msg>>", "kotlin.Pair", "oolong.Effect")
+)
 typealias Next<Model, Msg> = Pair<Model, Effect<Msg>>
 
 /**
  * Creates an initial state and side-effects
  */
-typealias Init<Model, Msg> = () -> Next<Model, Msg>
+typealias Init<Model, Msg> = () -> Pair<Model, Effect<Msg>>
 
 /**
  * Creates a next state and side-effects from a message and current state
@@ -32,7 +36,7 @@ typealias Init<Model, Msg> = () -> Next<Model, Msg>
  * @param msg the message to interpret
  * @param model the current state
  */
-typealias Update<Model, Msg> = (msg: Msg, model: Model) -> Next<Model, Msg>
+typealias Update<Model, Msg> = (msg: Msg, model: Model) -> Pair<Model, Effect<Msg>>
 
 /**
  * Creates view properties from the current state

--- a/oolong/src/commonMain/kotlin/oolong/types.kt
+++ b/oolong/src/commonMain/kotlin/oolong/types.kt
@@ -7,14 +7,14 @@ import kotlinx.coroutines.CoroutineScope
  *
  * @param msg the message to send
  */
-typealias Dispatch<Msg> = (msg: Msg) -> Unit
+typealias Dispatch<Msg> = (Msg) -> Unit
 
 /**
  * Runs a side-effect away from the runtime
  *
  * @param dispatch the dispatch function
  */
-typealias Effect<Msg> = suspend CoroutineScope.(dispatch: Dispatch<Msg>) -> Any?
+typealias Effect<Msg> = suspend CoroutineScope.(Dispatch<Msg>) -> Any?
 
 /**
  * A pair of the next state and side-effects
@@ -28,6 +28,10 @@ typealias Next<Model, Msg> = Pair<Model, Effect<Msg>>
 /**
  * Creates an initial state and side-effects
  */
+@Deprecated(
+    "Use () -> Pair<Model, Effect<Msg>> instead",
+    ReplaceWith("() -> Pair<Model, Effect<Msg>>", "kotlin.Pair", "oolong.Effect")
+)
 typealias Init<Model, Msg> = () -> Pair<Model, Effect<Msg>>
 
 /**
@@ -36,6 +40,10 @@ typealias Init<Model, Msg> = () -> Pair<Model, Effect<Msg>>
  * @param msg the message to interpret
  * @param model the current state
  */
+@Deprecated(
+    "Use (Msg, Model) -> Pair<Model, Effect<Msg>> instead",
+    ReplaceWith("(Msg, Model) -> Pair<Model, Effect<Msg>>", "kotlin.Pair", "oolong.Effect")
+)
 typealias Update<Model, Msg> = (msg: Msg, model: Model) -> Pair<Model, Effect<Msg>>
 
 /**
@@ -44,6 +52,10 @@ typealias Update<Model, Msg> = (msg: Msg, model: Model) -> Pair<Model, Effect<Ms
  * @param model the current state
  * @param dispatch the dispatch function
  */
+@Deprecated(
+    "Use (Model) -> Props instead",
+    ReplaceWith("(Model) -> Props")
+)
 typealias View<Model, Props> = (model: Model) -> Props
 
 /**
@@ -51,6 +63,10 @@ typealias View<Model, Props> = (model: Model) -> Props
  *
  * @param props view properties
  */
+@Deprecated(
+    "Use (Props, Dispatch<Msg>) -> Any? instead",
+    ReplaceWith("(Props, Dispatch<Msg>) -> Any?", "oolong.Dispatch")
+)
 typealias Render<Msg, Props> = (props: Props, dispatch: Dispatch<Msg>) -> Any?
 
 /**
@@ -68,21 +84,22 @@ typealias Dispose = () -> Unit
 fun <Msg> effect(block: Effect<Msg>): Effect<Msg> = block
 
 /**
- * [Init] builder function.
+ * Init builder function.
  */
-fun <Model, Msg> init(block: Init<Model, Msg>): Init<Model, Msg> = block
+fun <Model, Msg> init(block: () -> Pair<Model, Effect<Msg>>): () -> Pair<Model, Effect<Msg>> = block
 
 /**
- * [Update] builder function.
+ * Update builder function.
  */
-fun <Model, Msg> update(block: Update<Model, Msg>): Update<Model, Msg> = block
+fun <Model, Msg> update(block: (Msg, Model) -> Pair<Model, Effect<Msg>>): (Msg, Model) -> Pair<Model, Effect<Msg>> =
+    block
 
 /**
- * [View] builder function.
+ * View builder function.
  */
-fun <Model, Props> view(block: View<Model, Props>): View<Model, Props> = block
+fun <Model, Props> view(block: (Model) -> Props): (Model) -> Props = block
 
 /**
- * [Render] builder function.
+ * Render builder function.
  */
-fun <Props, Msg> render(block: Render<Props, Msg>): Render<Props, Msg> = block
+fun <Props, Msg> render(block: (Props, Dispatch<Msg>) -> Any?): (Props, Dispatch<Msg>) -> Any? = block

--- a/oolong/src/jvmTest/kotlin/oolong/RuntimeTest.kt
+++ b/oolong/src/jvmTest/kotlin/oolong/RuntimeTest.kt
@@ -129,10 +129,10 @@ private class RuntimeTest {
     }
 
     private fun <Model, Msg, Props> TestCoroutineScope.runtime(
-        init: Init<Model, Msg>,
-        update: Update<Model, Msg>,
-        view: View<Model, Props>,
-        render: Render<Msg, Props>
+        init: () -> Pair<Model, Effect<Msg>>,
+        update: (Msg, Model) -> Pair<Model, Effect<Msg>>,
+        view: (Model) -> Props,
+        render: (Props, Dispatch<Msg>) -> Any?
     ): Job = runtime(
         init,
         update,
@@ -144,10 +144,10 @@ private class RuntimeTest {
     )
 
     private fun <Model, Msg, Props> TestCoroutineScope.disposableRuntime(
-        init: Init<Model, Msg>,
-        update: Update<Model, Msg>,
-        view: View<Model, Props>,
-        render: Render<Msg, Props>
+        init: () -> Pair<Model, Effect<Msg>>,
+        update: (Msg, Model) -> Pair<Model, Effect<Msg>>,
+        view: (Model) -> Props,
+        render: (Props, Dispatch<Msg>) -> Any?
     ): Dispose = Oolong.runtime(
         init,
         update,


### PR DESCRIPTION
Although `Next` condenses the type it aliases, it obscures the underlying type and make construction of instances confusing and undiscoverable. See https://github.com/oolong-kt/oolong/issues/116. This PR takes a step toward solving this issue by removing the indirection.