### PR TITLE
Deprecate effect builders unrelated to core library.

### DIFF
--- a/oolong/src/commonMain/kotlin/oolong/delay/util.kt
+++ b/oolong/src/commonMain/kotlin/oolong/delay/util.kt
@@ -13,6 +13,7 @@ import oolong.Effect
  * @param msg generator function of [Msg]
  * @return a delayed effect
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> delay(timeMillis: Long, msg: suspend CoroutineScope.() -> Msg): Effect<Msg> =
     { dispatch ->
         delay(timeMillis)
@@ -26,6 +27,7 @@ fun <Msg> delay(timeMillis: Long, msg: suspend CoroutineScope.() -> Msg): Effect
  * @param msg generator function of [Msg]
  * @return a delayed effect
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> interval(timeMillis: Long, msg: suspend CoroutineScope.() -> Msg): Effect<Msg> =
     { dispatch ->
         while (isActive) {

--- a/oolong/src/commonMain/kotlin/oolong/random/util.kt
+++ b/oolong/src/commonMain/kotlin/oolong/random/util.kt
@@ -15,6 +15,7 @@ import kotlin.random.nextULong
  * @param msg map function of [Int] to [Msg]
  * @return [Effect] of [Msg] for the generated [Int]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextBits(bitCount: Int, msg: suspend CoroutineScope.(Int) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextBits(bitCount))) }
 
@@ -24,6 +25,7 @@ fun <Msg> nextBits(bitCount: Int, msg: suspend CoroutineScope.(Int) -> Msg): Eff
  * @param msg map function of [Boolean] to [Msg]
  * @return [Effect] of [Msg] for the generated [Boolean]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextBoolean(msg: suspend CoroutineScope.(Boolean) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextBoolean())) }
 
@@ -33,6 +35,7 @@ fun <Msg> nextBoolean(msg: suspend CoroutineScope.(Boolean) -> Msg): Effect<Msg>
  * @param msg map function of [ByteArray] to [Msg]
  * @return [Effect] of [Msg] for the generated [ByteArray]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextBytes(
     array: ByteArray,
     fromIndex: Int,
@@ -46,6 +49,7 @@ fun <Msg> nextBytes(
  * @param msg map function of [ByteArray] to [Msg]
  * @return [Effect] of [Msg] for the generated [ByteArray]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextBytes(array: ByteArray, msg: suspend CoroutineScope.(ByteArray) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextBytes(array))) }
 
@@ -55,6 +59,7 @@ fun <Msg> nextBytes(array: ByteArray, msg: suspend CoroutineScope.(ByteArray) ->
  * @param msg map function of [ByteArray] to [Msg]
  * @return [Effect] of [Msg] for the generated [ByteArray]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextBytes(size: Int, msg: suspend CoroutineScope.(ByteArray) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextBytes(size))) }
 
@@ -64,6 +69,7 @@ fun <Msg> nextBytes(size: Int, msg: suspend CoroutineScope.(ByteArray) -> Msg): 
  * @param msg map function of [Double] to [Msg]
  * @return [Effect] of [Msg] for the generated [Double]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextDouble(msg: suspend CoroutineScope.(Double) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextDouble())) }
 
@@ -73,6 +79,7 @@ fun <Msg> nextDouble(msg: suspend CoroutineScope.(Double) -> Msg): Effect<Msg> =
  * @param msg map function of [Double] to [Msg]
  * @return [Effect] of [Msg] for the generated [Double]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextDouble(until: Double, msg: suspend CoroutineScope.(Double) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextDouble(until))) }
 
@@ -82,6 +89,7 @@ fun <Msg> nextDouble(until: Double, msg: suspend CoroutineScope.(Double) -> Msg)
  * @param msg map function of [Double] to [Msg]
  * @return [Effect] of [Msg] for the generated [Double]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextDouble(from: Double, until: Double, msg: suspend CoroutineScope.(Double) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextDouble(from, until))) }
 
@@ -91,6 +99,7 @@ fun <Msg> nextDouble(from: Double, until: Double, msg: suspend CoroutineScope.(D
  * @param msg map function of [Float] to [Msg]
  * @return [Effect] of [Msg] for the generated [Float]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextFloat(msg: suspend CoroutineScope.(Float) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextFloat())) }
 
@@ -100,6 +109,7 @@ fun <Msg> nextFloat(msg: suspend CoroutineScope.(Float) -> Msg): Effect<Msg> =
  * @param msg map function of [Int] to [Msg]
  * @return [Effect] of [Msg] for the generated [Int]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextInt(msg: suspend CoroutineScope.(Int) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextInt())) }
 
@@ -109,6 +119,7 @@ fun <Msg> nextInt(msg: suspend CoroutineScope.(Int) -> Msg): Effect<Msg> =
  * @param msg map function of [Int] to [Msg]
  * @return [Effect] of [Msg] for the generated [Int]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextInt(until: Int, msg: suspend CoroutineScope.(Int) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextInt(until))) }
 
@@ -118,6 +129,7 @@ fun <Msg> nextInt(until: Int, msg: suspend CoroutineScope.(Int) -> Msg): Effect<
  * @param msg map function of [Int] to [Msg]
  * @return [Effect] of [Msg] for the generated [Int]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextInt(from: Int, until: Int, msg: suspend CoroutineScope.(Int) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextInt(from, until))) }
 
@@ -127,6 +139,7 @@ fun <Msg> nextInt(from: Int, until: Int, msg: suspend CoroutineScope.(Int) -> Ms
  * @param msg map function of [Int] to [Msg]
  * @return [Effect] of [Msg] for the generated [Int]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextInt(range: IntRange, msg: suspend CoroutineScope.(Int) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextInt(range))) }
 
@@ -136,6 +149,7 @@ fun <Msg> nextInt(range: IntRange, msg: suspend CoroutineScope.(Int) -> Msg): Ef
  * @param msg map function of [Long] to [Msg]
  * @return [Effect] of [Msg] for the generated [Long]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextLong(msg: suspend CoroutineScope.(Long) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextLong())) }
 
@@ -145,6 +159,7 @@ fun <Msg> nextLong(msg: suspend CoroutineScope.(Long) -> Msg): Effect<Msg> =
  * @param msg map function of [Long] to [Msg]
  * @return [Effect] of [Msg] for the generated [Long]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextLong(until: Long, msg: suspend CoroutineScope.(Long) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextLong(until))) }
 
@@ -154,6 +169,7 @@ fun <Msg> nextLong(until: Long, msg: suspend CoroutineScope.(Long) -> Msg): Effe
  * @param msg map function of [Long] to [Msg]
  * @return [Effect] of [Msg] for the generated [Long]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextLong(from: Long, until: Long, msg: suspend CoroutineScope.(Long) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextLong(from, until))) }
 
@@ -163,6 +179,7 @@ fun <Msg> nextLong(from: Long, until: Long, msg: suspend CoroutineScope.(Long) -
  * @param msg map function of [Long] to [Msg]
  * @return [Effect] of [Msg] for the generated [Long]
  */
+@Deprecated("To be removed in the next minor release")
 fun <Msg> nextLong(range: LongRange, msg: suspend CoroutineScope.(Long) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextLong(range))) }
 
@@ -172,6 +189,7 @@ fun <Msg> nextLong(range: LongRange, msg: suspend CoroutineScope.(Long) -> Msg):
  * @param msg map function of [UByteArray] to [Msg]
  * @return [Effect] of [Msg] for the generated [UByteArray]
  */
+@Deprecated("To be removed in the next minor release")
 @ExperimentalUnsignedTypes
 fun <Msg> nextUBytes(array: UByteArray, msg: suspend CoroutineScope.(UByteArray) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextUBytes(array))) }
@@ -182,6 +200,7 @@ fun <Msg> nextUBytes(array: UByteArray, msg: suspend CoroutineScope.(UByteArray)
  * @param msg map function of [UByteArray] to [Msg]
  * @return [Effect] of [Msg] for the generated [UByteArray]
  */
+@Deprecated("To be removed in the next minor release")
 @ExperimentalUnsignedTypes
 fun <Msg> nextUBytes(size: Int, msg: suspend CoroutineScope.(UByteArray) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextUBytes(size))) }
@@ -192,6 +211,7 @@ fun <Msg> nextUBytes(size: Int, msg: suspend CoroutineScope.(UByteArray) -> Msg)
  * @param msg map function of [UInt] to [Msg]
  * @return [Effect] of [Msg] for the generated [UInt]
  */
+@Deprecated("To be removed in the next minor release")
 @ExperimentalUnsignedTypes
 fun <Msg> nextUInt(msg: suspend CoroutineScope.(UInt) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextUInt())) }
@@ -202,6 +222,7 @@ fun <Msg> nextUInt(msg: suspend CoroutineScope.(UInt) -> Msg): Effect<Msg> =
  * @param msg map function of [UInt] to [Msg]
  * @return [Effect] of [Msg] for the generated [UInt]
  */
+@Deprecated("To be removed in the next minor release")
 @ExperimentalUnsignedTypes
 fun <Msg> nextUInt(until: UInt, msg: suspend CoroutineScope.(UInt) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextUInt(until))) }
@@ -212,6 +233,7 @@ fun <Msg> nextUInt(until: UInt, msg: suspend CoroutineScope.(UInt) -> Msg): Effe
  * @param msg map function of [UInt] to [Msg]
  * @return [Effect] of [Msg] for the generated [UInt]
  */
+@Deprecated("To be removed in the next minor release")
 @ExperimentalUnsignedTypes
 fun <Msg> nextUInt(from: UInt, until: UInt, msg: suspend CoroutineScope.(UInt) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextUInt(from, until))) }
@@ -222,6 +244,7 @@ fun <Msg> nextUInt(from: UInt, until: UInt, msg: suspend CoroutineScope.(UInt) -
  * @param msg map function of [UInt] to [Msg]
  * @return [Effect] of [Msg] for the generated [UInt]
  */
+@Deprecated("To be removed in the next minor release")
 @ExperimentalUnsignedTypes
 fun <Msg> nextUInt(range: UIntRange, msg: suspend CoroutineScope.(UInt) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextUInt(range))) }
@@ -232,6 +255,7 @@ fun <Msg> nextUInt(range: UIntRange, msg: suspend CoroutineScope.(UInt) -> Msg):
  * @param msg map function of [ULong] to [Msg]
  * @return [Effect] of [Msg] for the generated [ULong]
  */
+@Deprecated("To be removed in the next minor release")
 @ExperimentalUnsignedTypes
 fun <Msg> nextULong(msg: suspend CoroutineScope.(ULong) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextULong())) }
@@ -242,6 +266,7 @@ fun <Msg> nextULong(msg: suspend CoroutineScope.(ULong) -> Msg): Effect<Msg> =
  * @param msg map function of [ULong] to [Msg]
  * @return [Effect] of [Msg] for the generated [ULong]
  */
+@Deprecated("To be removed in the next minor release")
 @ExperimentalUnsignedTypes
 fun <Msg> nextULong(until: ULong, msg: suspend CoroutineScope.(ULong) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextULong(until))) }
@@ -252,6 +277,7 @@ fun <Msg> nextULong(until: ULong, msg: suspend CoroutineScope.(ULong) -> Msg): E
  * @param msg map function of [ULong] to [Msg]
  * @return [Effect] of [Msg] for the generated [ULong]
  */
+@Deprecated("To be removed in the next minor release")
 @ExperimentalUnsignedTypes
 fun <Msg> nextULong(from: ULong, until: ULong, msg: suspend CoroutineScope.(ULong) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextULong(from, until))) }
@@ -262,6 +288,7 @@ fun <Msg> nextULong(from: ULong, until: ULong, msg: suspend CoroutineScope.(ULon
  * @param msg map function of [ULong] to [Msg]
  * @return [Effect] of [Msg] for the generated [ULong]
  */
+@Deprecated("To be removed in the next minor release")
 @ExperimentalUnsignedTypes
 fun <Msg> nextULong(range: ULongRange, msg: suspend CoroutineScope.(ULong) -> Msg): Effect<Msg> =
     { dispatch -> dispatch(msg(Random.nextULong(range))) }


### PR DESCRIPTION
These functions are unrelated to the core library and should be removed. They may be added to another module in the future.