### PR TITLE
Add javascript targets, support for MacOS arm64 architecture, and upgrade Kotlin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ classes/
 
 ### Node ###
 node_modules/
+kotlin-js-store
 
 ### Dokka ###
 package-list

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,7 +1,7 @@
 ext.versions = [
-        kotlin          : '1.6.10',
+        kotlin          : '1.6.21',
         kotlinCoroutines: '1.6.2',
-        ktlint          : '0.45.2',
+ktlint          : '0.45.2',
 ]
 
 ext.deps = [
@@ -12,6 +12,7 @@ ext.deps = [
                 spotless: "com.diffplug.spotless:spotless-plugin-gradle:5.8.2",
         ],
         kotlin : [
+                atomicfu  : "org.jetbrains.kotlin:atomicfu:${versions.kotlin}",
                 test      : [
                         common           : "org.jetbrains.kotlin:kotlin-test-common:${versions.kotlin}",
                         commonAnnotations: "org.jetbrains.kotlin:kotlin-test-annotations-common:${versions.kotlin}",
@@ -19,7 +20,7 @@ ext.deps = [
                 ],
                 coroutines: [
                         "core": "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinCoroutines}",
-                        "test": "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinCoroutines}"
+                        "test": "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinCoroutines}",
                 ],
         ],
         junit  : 'junit:junit:4.13.2',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,7 +1,7 @@
 ext.versions = [
         kotlin          : '1.6.21',
         kotlinCoroutines: '1.6.2',
-ktlint          : '0.45.2',
+	ktlint          : '0.45.2',
 ]
 
 ext.deps = [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,7 +1,7 @@
 ext.versions = [
         kotlin          : '1.6.21',
-        kotlinCoroutines: '1.6.2',
-	ktlint          : '0.45.2',
+        kotlinCoroutines: '1.6.1',
+        ktlint          : '0.45.2',
 ]
 
 ext.deps = [
@@ -12,7 +12,6 @@ ext.deps = [
                 spotless: "com.diffplug.spotless:spotless-plugin-gradle:5.8.2",
         ],
         kotlin : [
-                atomicfu  : "org.jetbrains.kotlin:atomicfu:${versions.kotlin}",
                 test      : [
                         common           : "org.jetbrains.kotlin:kotlin-test-common:${versions.kotlin}",
                         commonAnnotations: "org.jetbrains.kotlin:kotlin-test-annotations-common:${versions.kotlin}",

--- a/oolong/build.gradle
+++ b/oolong/build.gradle
@@ -19,11 +19,20 @@ kotlin {
                 implementation deps.kotlin.test.junit
             }
         }
+        jsMain {
+            dependencies {
+                implementation deps.kotlin.atomicfu
+            }
+        }
         nativeMain {}
-        nativeTest{}
+        nativeTest {}
     }
 
     targetFromPreset(presets.jvm, 'jvm')
+    targetFromPreset(presets.jsIr, 'js') {
+        browser()
+        nodejs()
+    }
     targetFromPreset(presets.iosX64, 'iosX64')
     targetFromPreset(presets.iosArm32, 'iosArm32')
     targetFromPreset(presets.iosArm64, 'iosArm64')
@@ -33,6 +42,7 @@ kotlin {
     targetFromPreset(presets.watchosArm32, 'watchosArm32')
     targetFromPreset(presets.watchosArm64, 'watchosArm64')
     targetFromPreset(presets.macosX64, 'macosX64')
+    targetFromPreset(presets.macosArm64, 'macosArm64')
     targetFromPreset(presets.mingwX64, 'mingw')
 
     configure([
@@ -45,6 +55,7 @@ kotlin {
             targets.watchosArm32,
             targets.watchosArm64,
             targets.macosX64,
+            targets.macosArm64,
             targets.mingw
     ]) {
         compilations.main.source(sourceSets.nativeMain)

--- a/oolong/build.gradle
+++ b/oolong/build.gradle
@@ -19,11 +19,6 @@ kotlin {
                 implementation deps.kotlin.test.junit
             }
         }
-        jsMain {
-            dependencies {
-                implementation deps.kotlin.atomicfu
-            }
-        }
         nativeMain {}
         nativeTest {}
     }

--- a/oolong/src/jvmTest/kotlin/oolong/RuntimeTest.kt
+++ b/oolong/src/jvmTest/kotlin/oolong/RuntimeTest.kt
@@ -4,8 +4,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import oolong.next.next
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -16,7 +16,7 @@ import kotlin.test.fail
 class RuntimeTest {
 
     @Test
-    fun `runtime should call render initially`() = runBlockingTest {
+    fun `runtime should call render initially`() = runTest {
         val initialState = 1
         runtime(
             { next(initialState) },
@@ -29,7 +29,7 @@ class RuntimeTest {
     }
 
     @Test
-    fun `runtime should call render after dispatch`() = runBlockingTest {
+    fun `runtime should call render after dispatch`() = runTest {
         var count = 0
         runtime(
             { next("init") },
@@ -53,7 +53,7 @@ class RuntimeTest {
     }
 
     @Test
-    fun `effects do not block runtime`() = runBlockingTest {
+    fun `effects do not block runtime`() = runTest {
         val states = mutableListOf<String>()
         val initEffect = effect<String> { dispatch ->
             delay(100)
@@ -81,7 +81,7 @@ class RuntimeTest {
     }
 
     @Test
-    fun `runtime should not call update view render if cancelled`() = runBlockingTest {
+    fun `runtime should not call update view render if cancelled`() = runTest {
         var initialRender = true
         val nextEffect = effect { dispatch: Dispatch<String> -> dispatch("next") }
         val job = runtime(
@@ -96,7 +96,7 @@ class RuntimeTest {
         job.cancel()
     }
 
-    private fun <Model, Msg, Props> TestCoroutineScope.runtime(
+    private fun <Model, Msg, Props> TestScope.runtime(
         init: () -> Pair<Model, Effect<Msg>>,
         update: (Msg, Model) -> Pair<Model, Effect<Msg>>,
         view: (Model) -> Props,


### PR DESCRIPTION
Summary of changes:

- Includes an update to Kotlin 1.6.21
- Tests updated to no longer use deprecated APIs
- JS artifacts using IR backend (excludes legacy backend) for both browser and nodejs
- MacOS arm64 architecture support

_note_: atomicfu is required to compile JS targets with the IR backend and with coroutines version 1.6.2; a fix is coming in the next release, but I opted to downgrade coroutines to make project configuration easier in the short term.